### PR TITLE
Fix typo in artifact name for docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,4 +67,4 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
         with:
-          artefact_name: github-pages
+          artifact_name: github-pages


### PR DESCRIPTION
Turns out I can't spell `artifact` :sweat_smile: 