### PR TITLE
CI Fixes

### DIFF
--- a/src/tingan/gp_rednoise.py
+++ b/src/tingan/gp_rednoise.py
@@ -56,8 +56,8 @@ def load_gammas_and_amplitudes(psrs: tuple) -> tuple:
         dat_y_no_f2 -= np.polyval(p, dat_t)
         resid.append(dat_y_no_f2)
         time.append(dat_t)
-    i += 1
-    return gammas[:i], amplitudes[:i], tstart[:i], tspans[:i], resid[:i], time[:i]
+
+    return gammas, amplitudes, tstart, tspans, resid, time
 
 
 def gaussian_kde_1d(data: list | np.ndarray, size: int = 100) -> np.ndarray:

--- a/tests/test_gp_rednoise.py
+++ b/tests/test_gp_rednoise.py
@@ -7,10 +7,14 @@ from tingan import gp_rednoise as gp
 from tingan._tests.fake_data import fake_pulsar_data
 
 
+@pytest.mark.parametrize(
+    "expected_n_pulsars",
+    [pytest.param(21, id="Some pulsars"), pytest.param(0, id="No pulsars")],
+)
 def test_load_gammas_and_amplitudes(
     tmp_path: Path,
     n_boring_pulsars,
-    expected_n_pulsars: int = 21,
+    expected_n_pulsars: int,
 ) -> None:
     """Test that the correct number of parameters are loaded."""
     created_pulsars = n_boring_pulsars(expected_n_pulsars)

--- a/tests/test_gp_rednoise.py
+++ b/tests/test_gp_rednoise.py
@@ -18,22 +18,12 @@ def test_load_gammas_and_amplitudes(
 
     gammas, *_ = gp.load_gammas_and_amplitudes(fake_pulsar_dirs)
     assert len(gammas) == expected_n_pulsars
+
+
 @pytest.fixture
 def rng(seed: int = 0) -> np.random.Generator:
     """Set the RNG for the entire test suite."""
     return np.random.default_rng(seed)
-
-
-def test_load_gammas_and_amplitudes() -> None:
-    """Test that the correct number of parameters are loaded."""
-    # I know this is specific to my machine, but I got a bug with npsrs when passing
-    # psrs as a function argument. __sizeof__() used to return the number of pulsars,
-    # 21, but inside the function it returms 32. So I just want to make sure I loaded
-    # data for the correct number of pulsars.
-    psrs = tuple(Path("/home/jberteaud/Science/EOS/tingan/data/real/").glob("[JB]*"))
-    gammas, *_ = gp.load_gammas_and_amplitudes(psrs)
-    number_of_psrs_on_my_machine = 21
-    assert len(gammas) == number_of_psrs_on_my_machine
 
 
 def test_marginalize_2d_kde_with_ones() -> None:


### PR DESCRIPTION
CI on `main` is failing, likely due to some sneaky `rebase` errors. This PR should fix things:

- Removed a duplicate `test_load_gammas_and_amplitudes`. This test was defined twice, the old version from before #10 was merged still being present after the new version of this test. As such, the old version was running, rather than the new!
- `load_gammas_and_amplitudes` in `gp_rednoise.py` itself also threw an error when the number of pulsars (`psrs`) was 0. This resulted in the `for i, psr in enumerate(psrs)` loop to **not initialise** the variable `i`, which was then required after the loop had completed. However, `i` was only being used to slice the returned arrays as `array[:i]`, which is equivalent to just returning the whole array itself. As such, we can get away without using `i` outside the `for` loop, which in turn means that this "0-pulsars-case" no longer throws an error. Have added another test case that will catch any problems with this in the future.

(Apologies - turns out I had made a local branch to fix this, but just forgot to open the  PR! :sweat_smile: )